### PR TITLE
Added logic to run all Before and After PowerShell scripts. Added Env…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ ENV DEV_ISO=$DEV_ISO `
     sa_password="_" `
     attach_dbs="[]" `
     accept_eula="_" `
-    sa_password_path="C:\ProgramData\Docker\secrets\sa-password"
+    sa_password_path="C:\ProgramData\Docker\secrets\sa-password" `
+    before_startup="C:\before-startup" `
+    $after_startup="C:\after-startup"
 
 LABEL org.opencontainers.image.authors="Tobias Fenster (https://tobiasfenster.io)"
 LABEL org.opencontainers.image.source="https://github.com/tfenster/mssql-image"

--- a/start.ps1
+++ b/start.ps1
@@ -82,7 +82,7 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
 
 Write-Host "Started SQL Server."
 
-# run powershell scripts before starting SQL service
+# run powershell scripts after starting SQL service
 Write-Host "Running post start-up scripts:"
 if (-not (test-path $after_startup))
 {


### PR DESCRIPTION
Pull request for Run start-up script #5

I've tested it by creating 4 files in the `before-startup` and `after-startup` folders as follows:
- 1.ps1
- 2.ps1
- a.ps1
- b.ps1
- test.txt
This ran the 4 PowerShell files in the correct order and did not pick up the text file.

I've also tried the below environment values:
- (not set)
- valid path
- invalid path

I've made it so that if the paths are invalid the container still starts but doesn't run the scripts. it will output the below message in the console instead:
```
before_startup is not a valid path: $before_startup
Skipping pre start-up scripts
```